### PR TITLE
Update to newer fairseq and torch

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,59 +23,35 @@
   </tr>
 </table>
 
-# ModernMT on RTX 30XX
+# ModernMT on RTX 40XX
 
-There are some known speed issues on running ModernMT on RTX 30XX GPUs. This are due to the new version of fairseq (0.10) required for compatibility issues with the newest NVIDIA drivers that support these GPUs.
+ModernMT works correctly on the latest NVIDIA GPUs such as the RTX 4080 when using recent versions of PyTorch and Fairseq.
 
-_(Thanks to Loek van Kooten for this guide)_
+_(Thanks to Loek van Kooten for the original guide)_
 
-### 1. Install **NVIDIA drivers**:
-You need to install `nvidia-driver-455`. There's a possibility this doesn't work. In that case, you need to manually download the driver from NVIDIA's website and install it from there. Make sure you have deleted all NVIDIA drivers, CUDA files and cuDNN files from your system first. Do a complete purge (just make sure the nouveau driver stays alive). Or better: start from a clean system if you want to make absolutely sure.
+### 1. Install **NVIDIA drivers**
+Install the latest driver recommended for your GPU (for example `nvidia-driver-535` on Ubuntu).
 
 ```bash
 sudo add-apt-repository -y ppa:graphics-drivers
 sudo apt update
-sudo apt install -y nvidia-driver-455
+sudo apt install -y nvidia-driver-535
 ```
 
-### 2. Install ModernMT with custom requirements.txt
+### 2. Install ModernMT with updated requirements
 
-Follow the instructions [Install ModernMT from source](#install-modernmt-from-source) but, **before running `python3 setup.py`**, delete `requirements.txt` and rename `requirements_cuda-11.txt` to `requirements.txt`. This is what it should look like:
+Follow the instructions in [Install ModernMT from source](#install-modernmt-from-source) but, **before running `python3 setup.py`**, replace the `requirements.txt` file with the following content:
 ```
 regex
-sacrebleu==1.4.14
+sacrebleu==1.5.1
 requests
 cachetools
 tensorboardX==2.1
-torch==1.7.1+cu110
-fairseq==0.10.1
+torch>=2.1
+fairseq==0.12.2
 ```
 
-After that, continue installing ModernMT as indicated.
-
-### 3. Fix Fairseq
-
-Finally, we need to manually edit a `fairseq` file to fix a known issue.
-Edit the file `~/.local/lib/python3.8/site-packages/fairseq/utils.py` changing the lines 441-444 from:
-
-```python
-            fairseq_rel_path = os.path.join(os.path.dirname(__file__), args.user_dir)
-            if os.path.exists(fairseq_rel_path):
-                module_path = fairseq_rel_path
-            else:
-```
-
-to:
-
-```python
-            fairseq_rel_path = os.path.join(os.path.dirname(__file__), args.user_dir)
-            module_parent, module_name = os.path.split(module_path)
-            if os.path.exists(fairseq_rel_path):
-                module_path = fairseq_rel_path
-            elif not os.path.exists(module_parent):
-```
-
-Use a Python editor or make very sure you use indents, spaces and tabs consistently, else Python will throw an error.
+After that, continue installing ModernMT as indicated. No manual patching of Fairseq is required with these versions.
 
 # Install ModernMT via Docker
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 regex
-sacrebleu==1.3.1
+sacrebleu==1.5.1
 requests
 cachetools
-tensorboardX==1.6
-torch==1.3.0
-fairseq==0.7.1
+tensorboardX==2.1
+torch>=2.1
+fairseq==0.12.2

--- a/requirements_cuda-11.txt
+++ b/requirements_cuda-11.txt
@@ -1,7 +1,7 @@
 regex
-sacrebleu==1.4.14
+sacrebleu==1.5.1
 requests
 cachetools
 tensorboardX==2.1
-torch==1.7.1+cu110
-fairseq==0.10.1
+torch>=2.1
+fairseq==0.12.2

--- a/src/decoder-neural/src/main/python/mmt/__init__.py
+++ b/src/decoder-neural/src/main/python/mmt/__init__.py
@@ -13,9 +13,9 @@ if locale.getpreferredencoding().lower() != 'utf-8':
     raise UnicodeError('python locale preferred encoding is "%s", UTF-8 expected' % locale.getpreferredencoding())
 
 
-def is_fairseq_0_10():
+def is_fairseq_0_12():
     version = [int(n) for n in fairseq.__version__.split('.')]
-    return version[1] >= 10
+    return version[1] >= 12
 
 
 @register_task('mmt_translation')

--- a/src/decoder-neural/src/main/python/mmt/decoder.py
+++ b/src/decoder-neural/src/main/python/mmt/decoder.py
@@ -10,7 +10,7 @@ import torch
 from fairseq.models.transformer import TransformerModel
 from fairseq.sequence_generator import SequenceGenerator
 
-from mmt import textencoder, is_fairseq_0_10
+from mmt import textencoder, is_fairseq_0_12
 from mmt.alignment import make_alignment, clean_alignment
 from mmt.tuning import Tuner, TuningOptions
 
@@ -122,7 +122,7 @@ class MMTDecoder(object):
         kwargs = {'beam_size': beam_size, 'max_len_a': 0, 'max_len_b': 1, 'min_len': 1, 'normalize_scores': True,
                   'len_penalty': 1, 'unk_penalty': 0, 'temperature': 1}
 
-        if is_fairseq_0_10():
+        if is_fairseq_0_12():
             args.insert(0, models)
         else:
             kwargs.update({'stop_early': True, 'sampling': False, 'sampling_topk': -1,
@@ -135,7 +135,7 @@ class MMTDecoder(object):
         return Tuner(checkpoints.args, checkpoints.task, model, tuning_ops=tuning_ops, device=device)
 
     @classmethod
-    def port_to_fairseq_0_10(cls, checkpoint):
+    def port_to_fairseq_0_12(cls, checkpoint):
         missing_default_params = {'decoder_layers_to_keep': None, 'encoder_layers_to_keep': None,
                                   'encoder_layerdrop': 0, 'decoder_layerdrop': 0, 'quant_noise_pq': 0}
         for missing in missing_default_params.keys():
@@ -148,8 +148,8 @@ class MMTDecoder(object):
         self._checkpoints = checkpoints
         self._checkpoints.args.fp16 = use_fp16
 
-        if is_fairseq_0_10():
-            self.port_to_fairseq_0_10(self._checkpoints)
+        if is_fairseq_0_12():
+            self.port_to_fairseq_0_12(self._checkpoints)
 
         self._device = device
         self._model = self._fix_model_probs(

--- a/src/decoder-neural/src/main/python/mmt/tuning.py
+++ b/src/decoder-neural/src/main/python/mmt/tuning.py
@@ -6,7 +6,7 @@ import torch
 from fairseq import optim, utils
 from fairseq.data import LanguagePairDataset
 
-from mmt import is_fairseq_0_10
+from mmt import is_fairseq_0_12
 
 
 class TuningOptions(object):
@@ -67,7 +67,7 @@ class Tuner(object):
         self.__train_step_kwargs = {'ignore_grad': False}
         self.__dataset_kwargs = {'left_pad_source': True, 'left_pad_target': False}
 
-        if is_fairseq_0_10():
+        if is_fairseq_0_12():
             self.__train_step_kwargs['update_num'] = 1
         else:
             self.__dataset_kwargs['max_source_positions'] = 4096


### PR DESCRIPTION
## Summary
- update requirements to torch 2.1 and fairseq 0.12
- refresh GPU installation instructions
- adjust version checks to `is_fairseq_0_12`

## Testing
- `python3 test` *(fails: ModuleNotFoundError: No module named 'requests')*

------
