### PR TITLE
Fix argv parsing bug

### DIFF
--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -23,7 +23,7 @@ def argv_valueof(argv, *args):
             if arg == argv[i]:
                 return argv[i + 1]
             elif argv[i].startswith(arg + '='):
-                return argv[i][:len(arg) + 1]
+                return argv[i][len(arg) + 1:]
     return None
 
 

--- a/test/testcases/test_cli_utils.py
+++ b/test/testcases/test_cli_utils.py
@@ -1,0 +1,19 @@
+import unittest
+
+from cli import argv_valueof
+
+class ArgvValueOfTest(unittest.TestCase):
+    def test_arg_with_equals(self):
+        argv = ['prog', '--opt=value']
+        self.assertEqual(argv_valueof(argv, '--opt'), 'value')
+
+    def test_arg_as_separate(self):
+        argv = ['prog', '--opt', 'val']
+        self.assertEqual(argv_valueof(argv, '--opt'), 'val')
+
+    def test_missing_arg(self):
+        argv = ['prog']
+        self.assertIsNone(argv_valueof(argv, '--opt'))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix argv_valueof to return actual argument value after '='
- add unit tests for argv_valueof

## Testing
- `python3 -m unittest discover -s test/testcases -p 'test_cli_utils.py' -v`

------
